### PR TITLE
Add volkswagen implementation

### DIFF
--- a/csa_volkswagen.c
+++ b/csa_volkswagen.c
@@ -1,0 +1,1 @@
+char*x="1 2 3600 7200\n2 3 3321 9000\n1 3 *** 10000\n",*y,z[99],a,b,c,*gets(*);main(){while(b=c=2,y=gets(z)){while(a=*y++)b^=a,c+=a==32;a=51-x[b%5+18],c-4||dprintf(1,"%.*s\n",a%3*14,x+a/4*7);}}

--- a/makefile
+++ b/makefile
@@ -12,3 +12,6 @@ csa_c: csa.c
 
 csa_pascal: csa.pas
 	fpc csa.pas
+
+csa_volkswagen: csa_volkswagen.c
+	clang -w -Ofast -o csa_volkswagen csa_volkswagen.c


### PR DESCRIPTION
## Description

_Die Durchführung_ – A quick and small C variant
## Usage

Build with `clang -w -Ofast -o csa_volkswagen csa_volkswagen.c`

Run the test with `ruby test.rb ./csa_volkswagen`
## Advantages
- Passes<sup>(1)</sup> all the tests.
- Outperforms<sup>(2)</sup> the reference implementation.
- Only **194** characters. The smallest working<sup>(3)</sup> implementation to day.
## Limitations
- Your mileage may vary.
