### PR TITLE
Add ruby "golfed" version

### DIFF
--- a/csa_golfed.rb
+++ b/csa_golfed.rb
@@ -1,0 +1,1 @@
+I=10e5;u=[];u<<$_.split.map(&:to_i)while gets>$/;while gets>$/;d,a,t=$_.split.map &:to_i;j=Hash.new I;e=j.dup;e[d]=t;if d<=I&&a<=I;f=I;i=0;u.map{|m,n,o,p|if e[m]<o&&p<e[n];e[n]=p;j[n]=i;n==a&&p<f&&f=p;end;i+=1;p>f&&next};end;i=j[a];r=[];while i<I;r=[u[i]*" "]+r;i=j[u[i][0]];end;r[0]||="NO_SOLUTION";puts r<<"";$>.flush;end


### PR DESCRIPTION
The README asked for the most unreadable version, but sadly I didn't found anything regarding that functional requirement in the main branch. I hope I can win some points with this ruby ["golfed"](https://en.wikipedia.org/wiki/Code_golf) version.

It's probably also one of the shortest here. I'm confident it could be made shorter in perl, but my perl-foo isn't what it used to be, and we may also agree that J or GolfScript are not real languages so they don't qualify for your challenge.

The algorithm is pretty much the same as in the original ruby implementation, except I merged `MAX_STATIONS` and `INF` into a single `I`, which is fine for travels < 1 day and 4 hours. Making `I=10e6` works and would be fine in the general case, but it makes the program so slow I left it at `10e5`. Tests pass with `ruby test.rb "ruby csa_golfed.rb"` with MRI 2.2 at least.

PS: please take it for what it is: a funny logical/programming exercise and a (weird) joke :-)

EDIT: clarify comment about implementation
