### PR TITLE
Fixed pruning conditions in different implementations.

### DIFF
--- a/CSA.java
+++ b/CSA.java
@@ -59,7 +59,7 @@ public class CSA {
                 if(connection.arrival_station == arrival_station) {
                     earliest = Math.min(earliest, connection.arrival_timestamp);
                 }
-            } else if(connection.arrival_timestamp > earliest) {
+            } else if(connection.departure_timestamp >= earliest) {
                 return;
             }
         }

--- a/csa.c
+++ b/csa.c
@@ -91,7 +91,7 @@ void compute_route(array_of(connection) *timetable, request *rq)
             if(c->to == rq->to) {
                 earliest = MIN(earliest, c->end);
             }
-        } else if(c->end > earliest) {
+        } else if(c->start >= earliest) {
             break;
         }
     }

--- a/csa.cc
+++ b/csa.cc
@@ -57,7 +57,7 @@ struct CSA {
                 if(connection.arrival_station == arrival_station) {
                     earliest = std::min(earliest, connection.arrival_timestamp);
                 }
-            } else if(connection.arrival_timestamp > earliest) {
+            } else if(connection.departure_timestamp >= earliest) {
               return;
             }
         }

--- a/csa.hs
+++ b/csa.hs
@@ -75,7 +75,7 @@ augmentTimetable earliestArrival timetable@(Timetable arrivalTimes inConnections
           newTimetable     = Timetable newArrivalTimes newInConnections
       in augmentTimetable (min arrivalTime earliestArrival) newTimetable connections
     else
-      if arrivalTime > earliestArrival
+      if departureTime >= earliestArrival
       then
         timetable
       else

--- a/csa.lua
+++ b/csa.lua
@@ -40,7 +40,7 @@ function find(connections, earliest_arr, in_conn,  arr)
       if cas == arr then
         earliest = math.min(earliest, cat)
       end
-    elseif cat > earliest then
+    elseif cdt >= earliest then
       return
     end
   end

--- a/csa.pas
+++ b/csa.pas
@@ -42,7 +42,7 @@ begin
       if (timetable[i].arrivalStation = arrivalStation) then
         earliest := min(timetable[i].arrivalTime, earliest);
     end
-    else if (timetable[i].arrivalTime > earliest) then
+    else if (timetable[i].departureTime >= earliest) then
       Exit;
   end;
 end;

--- a/csa.py
+++ b/csa.py
@@ -46,7 +46,7 @@ class CSA:
 
                 if c.arrival_station == arrival_station:
                     earliest = min(earliest, c.arrival_timestamp)
-            elif c.arrival_timestamp > earliest:
+            elif c.departure_timestamp >= earliest:
                 return
 
     def print_result(self, arrival_station):

--- a/csa.rb
+++ b/csa.rb
@@ -48,7 +48,7 @@ class CSA
         if c.arrival_station == arrival_station
           earliest = [earliest, c.arrival_timestamp].min
         end
-      elsif c.arrival_timestamp > earliest
+      elsif c.departure_timestamp >= earliest
         return
       end
     end

--- a/csa.rs
+++ b/csa.rs
@@ -36,7 +36,7 @@ fn csa_main_loop(timetable: &[Connection], arrival_station: usize, earliest_arri
             if connection.arrival_station == arrival_station && connection.arrival_timestamp < earliest {
                 earliest = connection.arrival_timestamp;
             }
-        } else if connection.arrival_timestamp > earliest {
+        } else if connection.departure_timestamp >= earliest {
             break;
         }
     }


### PR DESCRIPTION
The algorithms were returning incorrect results due to bad pruning condition.
Only if the departure time of a connection is >= than the earliest arrival time at target, we can safely break the loop. 
